### PR TITLE
Delete duplicated <scene> element on worlds

### DIFF
--- a/gz_ekumen_worlds/worlds/empty_ekumen_hq4.world
+++ b/gz_ekumen_worlds/worlds/empty_ekumen_hq4.world
@@ -65,11 +65,6 @@
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>1000</real_time_update_rate>
     </physics>
-    <scene>
-      <ambient>0.4 0.4 0.4 1</ambient>
-      <background>0.7 0.7 0.7 1</background>
-      <shadows>1</shadows>
-    </scene>
     <audio>
       <device>default</device>
     </audio>

--- a/gz_ekumen_worlds/worlds/populated_ekumen_hq4.world
+++ b/gz_ekumen_worlds/worlds/populated_ekumen_hq4.world
@@ -65,11 +65,6 @@
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>1000</real_time_update_rate>
     </physics>
-    <scene>
-      <ambient>0.4 0.4 0.4 1</ambient>
-      <background>0.7 0.7 0.7 1</background>
-      <shadows>1</shadows>
-    </scene>
     <audio>
       <device>default</device>
     </audio>


### PR DESCRIPTION
# 🦟 Bug fix

<scene> element was duplicated on empty_ekumen_hq4.world as in polulated_ekumen_hq4.world

## Summary

Just deleted one of the duplicated elements

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)